### PR TITLE
Multi-threading and space safety on optimize-png

### DIFF
--- a/optimize-png.sh
+++ b/optimize-png.sh
@@ -8,8 +8,13 @@ if [[ -z "$input_dir" ]]; then
     exit 1
 fi
 
+# Multithreading count
+PROCS=$(grep processor /proc/cpuinfo | wc -l)
+
 # for each png in the input directory
-for img in $( find $input_dir -type f -iname "*.png" );
-do
-    optipng $img -out ${img%.*}-optimized.png
-done
+do_file() {
+    img="$1"
+    optipng "$img" -out "${img%.*}-optimized.png"
+}
+export -f do_file
+find "$input_dir" -type f -iname "*.png" -print0 | xargs -0 -n1 -P $PROCS bash -c 'do_file "$@"' _


### PR DESCRIPTION
"Space safety" means the script should work on files with spaces in their names.

I should really do this on all the scripts, but I'm too lazy.  Left as
an exercise for someone else.  optimize-png is likely the script that
uses the most CPU anyway.